### PR TITLE
Add docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.12"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "miniforge3-latest"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   builder: html
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
   fail_on_warning: true
 
 python:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+
+conda:
+  environment: docs/environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,9 @@ sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true
 
+# Don't build any extra output files
+formats: []
+
 python:
   install:
     - method: pip

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ xbudget: easy handling of budgets diagnosed from General Circulation Models with
 
 [![PyPI](https://badge.fury.io/py/xbudget.svg)](https://badge.fury.io/py/xbudget)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/xbudget)](https://anaconda.org/conda-forge/xbudget)
-[![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/xbudget?label=conda-forge)](https://anaconda.org/conda-forge/xbudget)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/hdrake/xbudget/CI.yml?logo=github)](https://github.com/hdrake/xbudget/actions)
 [![Docs](https://readthedocs.org/projects/xbudget/badge/?version=latest)](https://xbudget.readthedocs.io/en/latest/)
 [![License](https://img.shields.io/github/license/hdrake/xbudget)](https://github.com/hdrake/xbudget)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 xbudget: easy handling of budgets diagnosed from General Circulation Models with xarray
 =========================
 
-|pypi| |conda forge| |conda-forge| |Build Status| |docs| |license|
+[![PyPI](https://badge.fury.io/py/xbudget.svg)](https://badge.fury.io/py/xbudget)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/xbudget)](https://anaconda.org/conda-forge/xbudget)
+[![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/xbudget?label=conda-forge)](https://anaconda.org/conda-forge/xbudget)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/hdrake/xbudget/CI.yml?logo=github)](https://github.com/hdrake/xbudget/actions)
+[![Docs](https://readthedocs.org/projects/xbudget/badge/?version=latest)](https://xbudget.readthedocs.io/en/latest/)
+[![License](https://img.shields.io/github/license/hdrake/xbudget)](https://github.com/hdrake/xbudget)
 
-Quick Start Guide
------------------
-
+## Quick Start Guide
 **For users: minimal installation within an existing environment**
 ```bash
 pip install xbudget
@@ -21,20 +24,3 @@ pip install -e .
 python -m ipykernel install --user --name docs_env_xbudget --display-name "docs_env_xbudget"
 jupyter-lab
 ```
-
-.. |conda forge| image:: https://img.shields.io/conda/vn/conda-forge/xbudget
-   :target: https://anaconda.org/conda-forge/xbudget
-.. |Build Status| image:: https://img.shields.io/github/workflow/status/hdrake/xbudget/CI?logo=github
-   :target: https://github.com/hdrake/xbudget/actions
-   :alt: GitHub Workflow CI Status
-.. |pypi| image:: https://badge.fury.io/py/xbudget.svg
-   :target: https://badge.fury.io/py/xbudget
-   :alt: pypi package
-.. |docs| image:: http://readthedocs.org/projects/xbudget/badge/?version=latest
-   :target: http://xgcm.readthedocs.org/en/latest/?badge=latest
-   :alt: documentation status
-.. |license| image:: https://img.shields.io/github/license/mashape/apistatus.svg
-   :target: https://github.com/hdrake/xbudget
-   :alt: license
-.. |conda-forge| image:: https://img.shields.io/conda/dn/conda-forge/xbudget?label=conda-forge
-   :target: https://anaconda.org/conda-forge/xbudget

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# xbudget
-Helper functions and meta-data conventions for wrangling finite-volume ocean model budgets.
+xbudget: easy handling of budgets diagnosed from General Circulation Models with xarray
+=========================
+
+|pypi| |conda forge| |conda-forge| |Build Status| |docs| |license|
 
 Quick Start Guide
 -----------------
@@ -19,3 +21,20 @@ pip install -e .
 python -m ipykernel install --user --name docs_env_xbudget --display-name "docs_env_xbudget"
 jupyter-lab
 ```
+
+.. |conda forge| image:: https://img.shields.io/conda/vn/conda-forge/xbudget
+   :target: https://anaconda.org/conda-forge/xbudget
+.. |Build Status| image:: https://img.shields.io/github/workflow/status/hdrake/xbudget/CI?logo=github
+   :target: https://github.com/hdrake/xbudget/actions
+   :alt: GitHub Workflow CI Status
+.. |pypi| image:: https://badge.fury.io/py/xbudget.svg
+   :target: https://badge.fury.io/py/xbudget
+   :alt: pypi package
+.. |docs| image:: http://readthedocs.org/projects/xbudget/badge/?version=latest
+   :target: http://xgcm.readthedocs.org/en/latest/?badge=latest
+   :alt: documentation status
+.. |license| image:: https://img.shields.io/github/license/mashape/apistatus.svg
+   :target: https://github.com/hdrake/xbudget
+   :alt: license
+.. |conda-forge| image:: https://img.shields.io/conda/dn/conda-forge/xbudget?label=conda-forge
+   :target: https://anaconda.org/conda-forge/xbudget

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ xbudget: easy handling of budgets diagnosed from General Circulation Models with
 ## Quick Start Guide
 **For users: minimal installation within an existing environment**
 ```bash
-pip install xbudget
+conda install xbudget
 ```
 
 **For developers: installing from scratch using `conda`**

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,6 +1,7 @@
 name: test_env_xbudget
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python>=3.12
   - cftime

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "xbudget" %}
+{% set version = "0.6.2" %}
+{% set python_min = "3.11" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/x/xbudget/xbudget-{{ version }}.tar.gz
+  sha256: 0ab9571aae2196523c0dbc394468567446d61e475624921055a3b1e074c05112
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - hatchling
+  run:
+    - python >={{ python_min }}
+    - numpy
+    - xarray
+    - xgcm >=0.9.0
+
+test:
+  requires:
+    - python {{ python_min }}
+  imports:
+    - xbudget
+
+about:
+  home: https://github.com/hdrake/xbudget
+  summary: Helper functions and metadata conventions for wrangling finite-volume ocean model budgets
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - hdrake

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,4 +11,6 @@ dependencies:
   - pydap
   - pytest
   - sphinx
+  - nbsphinx
+  - ipykernel
   - pip

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: docs_env_xbudget
 channels:
   - conda-forge
 dependencies:
-  - python==3.12
+  - python=3.12
   - cftime
   - ipython
   - jupyterlab

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,4 +10,5 @@ dependencies:
   - netcdf4
   - pydap
   - pytest
+  - sphinx
   - pip

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,39 @@
+/* Responsive layout widening for Alabaster
+   - On small screens: use full width (with padding)
+   - On typical laptops: ~1100–1250px content area
+   - On big screens: cap so lines don't get absurdly long
+*/
+
+div.document {
+  /* Total doc block width (sidebar + content) */
+  width: min(96vw, 1400px);
+  margin: 0 auto;
+}
+
+/* Keep the main content comfortable: cap line length */
+div.body {
+  /* body width within the document area */
+  max-width: 900px;
+}
+
+/* Give the sidebar a stable width; let it wrap below on small screens */
+div.sphinxsidebar {
+  width: 270px;
+}
+
+/* On narrower screens, don't force sidebar + body side-by-side */
+@media (max-width: 900px) {
+  div.document {
+    width: 96vw;
+  }
+  div.sphinxsidebar {
+    float: none;
+    width: auto;
+  }
+  div.bodywrapper {
+    margin: 0;
+  }
+  div.body {
+    max-width: none;
+  }
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,8 +64,14 @@ _sync_examples()
 
 html_title = f"{project} v{version} documentation"
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+
+html_theme_options = {
+    "sidebar_width": "270px",
+}
+
+html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 
 latex_documents = [
     ("index")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,30 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'xbudget'
+copyright = '2026, Henri Drake'
+author = 'Henri Drake'
+
+from importlib.metadata import version as get_version
+
+release = get_version(project)
+version = ".".join(release.split(".")[:2])
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,6 +3,10 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+from importlib.metadata import version as get_version
+from pathlib import Path
+import shutil
+
 # The master toctree document.
 master_doc = "index"
 
@@ -14,17 +18,46 @@ project = 'xbudget'
 copyright = '2026, Henri Drake'
 author = 'Henri Drake'
 
-from importlib.metadata import version as get_version
 release = get_version(project)
 version = ".".join(release.split(".")[:2])
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = [
+    "nbsphinx"
+]
 
 templates_path = ['_templates']
 exclude_patterns = []
+
+# Don't execute notebooks on RTD unless you want that
+nbsphinx_execute = "never"
+
+# -- Copy notebooks from repo root/examples into docs/source/examples --------
+
+HERE = Path(__file__).resolve()
+DOCS_SOURCE = HERE.parent                       # docs/source
+REPO_ROOT = HERE.parents[2]                     # up two levels from conf.py
+EXAMPLES_SRC = REPO_ROOT / "examples"
+EXAMPLES_DST = DOCS_SOURCE / "examples"
+
+def _sync_examples():
+    if not EXAMPLES_SRC.exists():
+        return
+
+    # fresh copy so removed notebooks don't linger
+    if EXAMPLES_DST.exists():
+        shutil.rmtree(EXAMPLES_DST)
+    EXAMPLES_DST.mkdir(parents=True, exist_ok=True)
+
+    for nb in EXAMPLES_SRC.rglob("*.ipynb"):
+        rel = nb.relative_to(EXAMPLES_SRC)
+        out = EXAMPLES_DST / rel
+        out.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(nb, out)
+
+_sync_examples()
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,15 +3,18 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+# The master toctree document.
+master_doc = "index"
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
 
 project = 'xbudget'
 copyright = '2026, Henri Drake'
 author = 'Henri Drake'
 
 from importlib.metadata import version as get_version
-
 release = get_version(project)
 version = ".".join(release.split(".")[:2])
 
@@ -26,5 +29,11 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
+html_title = f"{project} v{version} documentation"
+
 html_theme = 'alabaster'
 html_static_path = ['_static']
+
+latex_documents = [
+    ("index")
+]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,13 @@
+
+xbudget documentation
+=====================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,3 +12,4 @@ documentation for details.
    :caption: Contents:
 
    installation
+   examples/MOM6_budget_examples_mass_heat_salt

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,6 @@
 
 xbudget: easy handling of budgets diagnosed from General Circulation Models with xarray
-=====================
+========================================================================================
 
 *xbudget* is a python package that facilitates the handling of budget diagnostics for finite-volume General Circulation Models (currently only supporting structured grids).
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ where :math:`\lambda` is the property density (or tracer concentration), :math:`
 
 xbudget ingests an `xgcm.Grid` object containing the budget diagnostics and uses structured metadata, in the form of a nested dictionary (or `.yaml` file), to close such budgets. While this may seem trivial for use cases in which there is a single flux to keep track of, total non-advective fluxes in general circulation models can be composed of dozens of contributing processes. Since budget diagnostics are often not output as volume-integrated tendencies, xbudget allows for terms to be derived as sums, products, or differences (or some combination of these). For example, ocean heat tendency due to air-sea heat fluxes might be derived from the difference between vertical heat fluxes across depth interfaces, summed over longwave, shortwave, sensible, and latent components of the flux, and multiplied by the ocean cell area.
 
-While drafting a `.yaml` file from scratch for a new model can be daunting, it only needs to be done once and then handling the budgets becomes trivially easy.
+While drafting a `.yaml` file from scratch for a new model can be daunting, it only needs to be done once -- then closing budgets is a breeze!
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@
 xbudget: easy handling of budgets diagnosed from General Circulation Models with xarray
 ========================================================================================
 
-*xbudget* is a python package that facilitates the handling of budget diagnostics for finite-volume General Circulation Models (currently only supporting structured grids).
+**xbudget** is a python package that facilitates the handling of budget diagnostics for finite-volume General Circulation Models (currently only supporting structured grids).
 
 xbudget expects budgets which have a Left-Hand Side (LHS) equal to a Right-Hand Side (RHS), typically in one of the following two forms:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,11 +1,19 @@
 
-xbudget documentation
+xbudget: easy handling of budgets diagnosed from General Circulation Models with xarray
 =====================
 
-Add your content using ``reStructuredText`` syntax. See the
-`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
-documentation for details.
+*xbudget* is a python package that facilitates the handling of budget diagnostics for finite-volume General Circulation Models (currently only supporting structured grids).
 
+xbudget expects budgets which have a Left-Hand Side (LHS) equal to a Right-Hand Side (RHS), typically in one of the following two forms:
+
+.. math::
+   \frac{\partial}{\partial t} \int \rho \lambda \, dV = \int \left[ - \nabla \cdot \left( \mathbf{F}_{\lambda} + \rho \lambda \mathbf{u} \right) \right] \, dV 
+
+where :math:`\lambda` is the property density (or tracer concentration), :math:`\mathbf{u}` is the flow velocity, and :math:`\mathbf{F}_{\lambda}` is the sum of all non-advective fluxes of :math:`\lambda`.
+
+xbudget ingests an `xgcm.Grid` object containing the budget diagnostics and uses structured metadata, in the form of a nested dictionary (or `.yaml` file), to close such budgets. While this may seem trivial for use cases in which there is a single flux to keep track of, total non-advective fluxes in general circulation models can be composed of dozens of contributing processes. Since budget diagnostics are often not output as volume-integrated tendencies, xbudget allows for terms to be derived as sums, products, or differences (or some combination of these). For example, ocean heat tendency due to air-sea heat fluxes might be derived from the difference between vertical heat fluxes across depth interfaces, summed over longwave, shortwave, sensible, and latent components of the flux, and multiplied by the ocean cell area.
+
+While drafting a `.yaml` file from scratch for a new model can be daunting, it only needs to be done once and then handling the budgets becomes trivially easy.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,3 +11,4 @@ documentation for details.
    :maxdepth: 2
    :caption: Contents:
 
+   installation

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Installation
 Requirements
 ^^^^^^^^^^^^
 
-xbudget is compatible with python 3 (>= version 3.11). It requires xgcm_
+xbudget is compatible with python 3 (>= version 3.11). It requires xgcm
 (>= version 0.9.0).
 
 Installation from Conda Forge

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,0 +1,45 @@
+
+Installation
+------------
+
+Requirements
+^^^^^^^^^^^^
+
+xbudget is compatible with python 3 (>= version 3.11). It requires xgcm_
+(>= version 0.9.0).
+
+Installation from Conda Forge
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The easiest way to install xbudget along with its dependencies is via conda
+forge::
+
+    conda install -c conda-forge xbudget
+
+
+Installation from Pip
+^^^^^^^^^^^^^^^^^^^^^
+
+An alternative is to use pip::
+
+    pip install xbudget
+
+This will install the latest release from
+`pypi <https://pypi.python.org/pypi>`_.
+
+Installation from GitHub
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+xbudget is under active development. To obtain the latest development version,
+you may clone the `source repository <https://github.com/hdrake/xbudget>`_
+and install it using pip::
+
+    pip install git+https://github.com/hdrake/xbudget.git
+
+More comprehensive instructions for installing a development environment can be found in the Contributor Guide (coming soon).
+
+Users are encouraged to `fork <https://help.github.com/articles/fork-a-repo/>`_
+xbudget and submit issues_ and `pull requests`_.
+
+.. _issues: https://github.com/hdrake/xbudget/issues
+.. _`pull requests`: https://github.com/hdrake/xbudget/pulls

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,4 +1,3 @@
-
 Installation
 ------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [


### PR DESCRIPTION
This pull request introduces configuration improvements to support building documentation with Sphinx and Read the Docs. The main changes are the addition of a `.readthedocs.yaml` configuration file and updating the documentation dependencies.

**Documentation build configuration:**

* Added a `.readthedocs.yaml` file to configure Read the Docs, specifying the OS, Python version, Sphinx build settings, and dependency installation methods.

**Documentation dependencies:**

* Added `sphinx` to the `docs/environment.yml` dependencies to ensure Sphinx is available for documentation builds.