### PR TITLE
Warn on 2D-over-3D broadcasting in budget sums (issue #11)

### DIFF
--- a/xbudget/collect.py
+++ b/xbudget/collect.py
@@ -112,6 +112,40 @@ def _warn_missing_variable(name):
         UserWarning,
     )
 
+
+def _warn_if_summands_broadcast(op_list, name):
+    """Warn when a ``sum`` mixes operands of differing dimensionality (issue #11).
+
+    In a finite-volume budget every term of a ``sum`` should live on the same
+    grid and therefore carry identical dimensions. When they do not, ``xarray``
+    silently broadcasts the lower-rank operand across the dimensions it lacks —
+    so a 2D surface flux summed with a 3D flux convergence is spread *uniformly*
+    over the vertical rather than deposited at the single level that outcrops.
+    That is almost never the intended finite-volume broadcast, and the recipe
+    does not carry the outcropping level needed to do it correctly, so for now
+    we surface the situation loudly instead of returning a wrong budget.
+
+    Only ``xr.DataArray`` operands are compared; scalar constants (``sign``,
+    ``density``, …) are ignored.
+    """
+    dim_sets = [frozenset(o.dims) for o in op_list if isinstance(o, xr.DataArray)]
+    if len(dim_sets) < 2:
+        return
+    common = frozenset.intersection(*dim_sets)
+    broadcast_dims = frozenset.union(*dim_sets) - common
+    if broadcast_dims:
+        warnings.warn(
+            f"Summing terms with mismatched dimensions while building "
+            f"'{name}': the operands carry dimension sets "
+            f"{[tuple(sorted(s)) for s in dim_sets]}. xarray will broadcast the "
+            f"lower-dimensional term(s) across {tuple(sorted(broadcast_dims))}, "
+            f"e.g. spreading a 2D surface flux uniformly over the vertical of a "
+            f"3D flux convergence instead of depositing it at the outcropping "
+            f"level. Verify this broadcast is intended; see "
+            f"https://github.com/hdrake/xbudget/issues/11.",
+            UserWarning,
+        )
+
 def lateral_divergence(grid, Fx, Fy):
     """Horizontal flux divergence ``div(Fx, Fy)`` on cell centers, via xgcm.
 
@@ -448,6 +482,8 @@ def budget_fill_dict(data, xbudget_dict, namepath, allow_rechunk = True):
             ):
                 return None
             else:
+                if k == "sum":
+                    _warn_if_summands_broadcast(op_list, f"{namepath}_{k}")
                 var = sum(op_list) if k=="sum" else reduce(mul, op_list, 1)
                 if not isinstance(var, xr.DataArray):
                     continue

--- a/xbudget/evaluate.py
+++ b/xbudget/evaluate.py
@@ -29,7 +29,11 @@ from .nodes import (
     Term,
     VarRef,
 )
-from .collect import _warn_missing_variable, lateral_divergence
+from .collect import (
+    _warn_if_summands_broadcast,
+    _warn_missing_variable,
+    lateral_divergence,
+)
 
 
 def _new_name(path):
@@ -193,6 +197,8 @@ class _Evaluator:
 
         if len(op_list) == 0:
             return None, None
+        if op.kind == "sum":
+            _warn_if_summands_broadcast(op_list, legacy_namepath)
         var = sum(op_list) if op.kind == "sum" else reduce(mul, op_list, 1)
         if not isinstance(var, xr.DataArray):
             # Reduced to a pure scalar (e.g. all variable operands missing);

--- a/xbudget/tests/test_broadcast_warning.py
+++ b/xbudget/tests/test_broadcast_warning.py
@@ -1,0 +1,97 @@
+"""Regression tests for issue #11: summing a 2D surface flux with a 3D flux
+convergence silently broadcasts the surface flux over every vertical level.
+
+Both engines should now emit a ``UserWarning`` when a ``sum`` mixes operands of
+differing dimensionality, so the wrong finite-volume broadcast is at least
+loud rather than silent. A well-formed budget whose summands all share the same
+dimensions must stay quiet.
+"""
+import copy
+import warnings
+
+import numpy as np
+import pytest
+import xarray as xr
+import xgcm
+
+import xbudget
+from xbudget.collect import _warn_if_summands_broadcast
+
+from conftest import SYNTHETIC_PRESET
+
+
+def _mixed_rank_grid():
+    """A grid with a 3D flux convergence and a 2D surface flux on cell centers."""
+    ds = xr.Dataset(
+        {
+            "conv3d": xr.DataArray(np.ones((2, 4, 3)), dims=("z", "x_c", "y_c")),
+            "surf2d": xr.DataArray(np.ones((4, 3)) * 10.0, dims=("x_c", "y_c")),
+        },
+        coords={
+            "z": np.arange(2),
+            "x_c": np.arange(4) + 0.5,
+            "y_c": np.arange(3),
+        },
+    ).chunk()
+    return xgcm.Grid(
+        ds,
+        coords={"X": {"center": "x_c"}},
+        padding="fill",
+        autoparse_metadata=False,
+    )
+
+
+MIXED_RANK_PRESET = {
+    "heat": {
+        "rhs": {
+            "var": None,
+            "sum": {
+                "var": None,
+                "convergence": {"var": "conv3d"},
+                "surface": {"var": "surf2d"},
+            },
+        }
+    }
+}
+
+
+# -- the helper in isolation ------------------------------------------------
+
+
+def test_helper_warns_on_mismatched_dims():
+    a = xr.DataArray(np.ones((2, 3, 4)), dims=("z", "y", "x"))
+    b = xr.DataArray(np.ones((3, 4)), dims=("y", "x"))
+    with pytest.warns(UserWarning, match="mismatched dimensions"):
+        _warn_if_summands_broadcast([a, b], "some_term")
+
+
+def test_helper_quiet_on_matching_dims_and_scalars():
+    a = xr.DataArray(np.ones((3, 4)), dims=("y", "x"))
+    b = xr.DataArray(np.ones((3, 4)), dims=("y", "x"))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning here fails the test
+        _warn_if_summands_broadcast([a, b, -1.0, 1035.0], "some_term")
+        _warn_if_summands_broadcast([a], "lone_term")
+
+
+# -- end to end through both engines ----------------------------------------
+
+
+@pytest.mark.parametrize("name_scheme", ["v1", "legacy"])
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_mixed_rank_sum_warns(name_scheme):
+    grid = _mixed_rank_grid()
+    with pytest.warns(UserWarning, match="mismatched dimensions"):
+        xbudget.collect_budgets(
+            grid, copy.deepcopy(MIXED_RANK_PRESET), name_scheme=name_scheme
+        )
+
+
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_wellformed_sum_is_quiet(synthetic_grid):
+    """The all-2D synthetic preset must not trip the broadcast warning."""
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        xbudget.collect_budgets(synthetic_grid, copy.deepcopy(SYNTHETIC_PRESET))
+    broadcast = [w for w in record if "mismatched dimensions" in str(w.message)]
+    assert broadcast == []


### PR DESCRIPTION
## Summary

Short-term mitigation for #11, stacked on top of #26 (`typed-engine-refactor`).

When a budget `sum` mixes a **2D surface flux** with a **3D flux convergence**, xarray silently broadcasts the 2D operand across the vertical coordinate — so the surface flux is spread *uniformly over every level* instead of being deposited at the single outcropping level. Both engines did a naive `sum(op_list)` with no guard, so the wrong budget was produced silently.

Reproduced against `typed-engine-refactor`:

```
conv3d (z,y,x) + surf2d (y,x)  ->  result (z,y,x), value 11.0 at BOTH z=0 and z=1
                                    (surface flux of 10 added at every level)
```

## What this does

- Adds `_warn_if_summands_broadcast(op_list, name)` in `collect.py`: compares the dimension sets of the `DataArray` summands (scalar constants like `sign`/`density` ignored) and emits a `UserWarning` naming the term and the broadcast dimensions when they differ.
- Wires it into **both** the typed evaluator (`evaluate.py::_eval_nary`) and the legacy `budget_fill_dict` (`collect.py`), ahead of the `sum`, so the two engines stay consistent.

This is exactly the "trigger a User Warning whenever such broadcasting occurs" step the issue asks for in the short term. It does **not** attempt the correct broadcast — that needs the outcropping level, which the recipe does not carry (in density coordinates any level can outcrop), and is left as the issue's long-term item.

## Scope / safety

- Only `sum` is guarded. `product` broadcasting (e.g. a 3D per-layer tendency × a 2D `areacello`) is intended and stays silent.
- A well-formed budget whose summands share dimensions emits nothing — verified on the all-2D synthetic preset.

## Tests

`xbudget/tests/test_broadcast_warning.py` (new): the helper in isolation (warns on mismatch, quiet on matching dims + scalars), both engines end to end via `collect_budgets(..., name_scheme="v1"|"legacy")`, and a guard that the synthetic preset stays quiet.

Full suite under xgcm 0.10.0: **115 passed, 5 skipped** (the 5 are the data-gated MOM6/ECCO tests).

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)